### PR TITLE
Fix for banner outputted twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+## [8.0.0] – 2019-03-08
+### Fixed
+* [#146] Banner is outputted twice.
+
+### Changed
+* [#146] **BREAKING CHANGE**: bump Rollup dependency to `^1.6.0`.
+
 ## [7.0.0] – 2019-01-17
 ### Added
 * [#143] **BREAKING CHANGE**: add support for Rollup `^1.0.0`.
@@ -164,7 +171,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#138]: https://github.com/Comandeer/rollup-plugin-babel-minify/issues/138
 [#143]: https://github.com/Comandeer/rollup-plugin-babel-minify/pull/143
 [#144]: https://github.com/Comandeer/rollup-plugin-babel-minify/issues/144
+[#146]: https://github.com/Comandeer/rollup-plugin-babel-minify/issues/146
 
+[8.0.0]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v7.0.0...v8.0.0
 [7.0.0]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v6.2.0...v7.0.0
 [6.2.0]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v6.1.1...v6.2.0
 [6.1.1]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v6.1.0...v6.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -8111,20 +8111,26 @@
       }
     },
     "rollup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.0.tgz",
-      "integrity": "sha512-LV6Qz+RkuDAfxr9YopU4k5o5P/QA7YNq9xi2Ug2IqOmhPt9sAm89vh3SkNtFok3bqZHX54eMJZ8F68HPejgqtw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.6.0.tgz",
+      "integrity": "sha512-qu9iWyuiOxAuBM8cAwLuqPclYdarIpayrkfQB7aTGTiyYPbvx+qVF33sIznfq4bxZCiytQux/FvZieUBAXivCw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*",
-        "acorn": "^6.0.4"
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "11.10.5",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.10.5.tgz",
+          "integrity": "sha512-DuIRlQbX4K+d5I+GMnv+UfnGh+ist0RdlvOp+JZ7ePJ6KQONCFQv/gKYSU1ZzbVdFSUCKZOltjmpFAGGv5MdYA==",
+          "dev": true
+        },
         "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "scope": "\\S+.*"
   },
   "peerDependencies": {
-    "rollup": "^1.0.0"
+    "rollup": "^1.6.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-async-generators": "^7.2.0",
@@ -84,7 +84,7 @@
     "mocha": "^6.0.0",
     "nyc": "^13.0.1",
     "rimraf": "^2.6.2",
-    "rollup": "^1.0.0",
+    "rollup": "^1.6.0",
     "sourcemap-validator": "^1.0.6"
   },
   "config": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,21 @@ import { isFn } from './utils.js';
 import { isFnOrString } from './utils.js';
 
 function minify( options = {} ) {
+	let bundleBanner;
+
 	return {
 		name: 'babel-minify',
 
-		renderChunk( bundle, chunkInfo, { banner: bundleBanner } ) {
+		outputOptions( outputOptions ) {
+			const result = Object.assign( {}, outputOptions );
+			bundleBanner = result.banner;
+
+			delete result.banner;
+
+			return result;
+		},
+
+		renderChunk( bundle ) {
 			const minifyOptions = filterMinifyOptions( options );
 			const babelConf = {
 				presets: [ [ minifyPreset, minifyOptions ] ],

--- a/tests/banner.js
+++ b/tests/banner.js
@@ -51,6 +51,32 @@ describe( 'banner and comments support', () => {
 		} );
 	} );
 
+	// #146
+	it( 'adds banner inherited from bundle.generate only once when comments are enabled', () => {
+		const rollupOptions = Object.assign( {}, defaultRollupOptions );
+		// Plugin adding banner dynamically is used to ensure that test passes due to fix,
+		// not due to the fact that plugin does not insert banner on its own, causing that
+		// banner is inserted only once (by Rollup).
+		const bannerPlugin = {
+			outputOptions( outputOptions ) {
+				return Object.assign( {}, outputOptions, {
+					banner: '/* hublabubla */'
+				} );
+			}
+		};
+
+		rollupOptions.plugins = [ ... rollupOptions.plugins ];
+		rollupOptions.plugins.unshift( bannerPlugin );
+
+		return createTransformTest( {
+			rollupOptions,
+			bundleOptions: defaultBundleOptions
+		} ).then( ( { bundle } ) => {
+			expect( bundle.code ).to.match( /^\/\* hublabubla \*\// );
+			expect( bundle.code ).not.to.match( /^(\/\* hublabubla \*\/\s*){2,}/ );
+		} );
+	} );
+
 	it( 'adds banner inherited from root configuration', () => {
 		const bannerOptions = {
 			output: {

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -60,6 +60,16 @@ describe( 'Rollup CLI', () => {
 		} );
 	} );
 
+	// #146
+	it( 'banner inherited not outputted twice', () => {
+		return executeRollupCmd( 'bannerInheritTwice' ).then( () => {
+			const { [ 'bundle.js' ]: code } = getArtifacts();
+
+			expect( code ).to.match( /^\/\* hublabubla \*\// );
+			expect( code ).not.to.match( /^(\/\* hublabubla \*\/\s*){2,}/ );
+		} );
+	} );
+
 	// #139
 	it( 'multiple chunks (dynamic import)', () => {
 		const artifacts = [

--- a/tests/fixtures/simple-project/rollup.config.bannerInheritTwice.js
+++ b/tests/fixtures/simple-project/rollup.config.bannerInheritTwice.js
@@ -1,0 +1,24 @@
+import minify from '../../../dist/rollup-plugin-babel-minify.es2015.js';
+
+export default {
+	input: 'index.js',
+	plugins: [
+		// Plugin adding banner dynamically is used to ensure that test passes due to fix,
+		// not due to the fact that plugin does not insert banner on its own, causing that
+		// banner is inserted only once (by Rollup).
+		{
+			outputOptions( outputOptions ) {
+				return Object.assign( {}, outputOptions, {
+					banner: '/* hublabubla */'
+				} );
+			}
+		},
+
+		minify()
+	],
+	output: {
+		sourcemap: true,
+		file: 'bundle.js',
+		format: 'es'
+	}
+};


### PR DESCRIPTION
The fix uses `outputOptions` hook available in Rollup ^1.6.0. Therefore this PR introduces breaking change (minimal version of Rollup peer dependency has changed).

Closes #146.